### PR TITLE
Dynamically check if the model was changed or is dirty

### DIFF
--- a/src/LaravelAttributeObserverServiceProvider.php
+++ b/src/LaravelAttributeObserverServiceProvider.php
@@ -146,7 +146,7 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
     }
 
     /**
-     * Properly check if the model was changed or is dirty.
+     * Dynamically check if the model was changed or is dirty.
      *
      * @param Model $model
      * @param string $event
@@ -155,12 +155,8 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
      */
     private function wasChanged(Model $model, string $event, string $attribute = null): bool
     {
-        $postEvents = [
-            'created',
-            'updated',
-            'saved',
-            'deleted',
-        ];
+        // Pull past-tense/post-mutation events from constants array
+        $postEvents = array_filter(self::EVENTS, fn($event) => Str::endsWith($event, 'ed'));
 
         if (in_array($event, $postEvents)) {
             return $attribute

--- a/src/LaravelAttributeObserverServiceProvider.php
+++ b/src/LaravelAttributeObserverServiceProvider.php
@@ -156,7 +156,7 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
     private function wasChanged(Model $model, string $event, string $attribute = null): bool
     {
         // Pull past-tense/post-mutation events from constants array
-        $postEvents = array_filter(self::EVENTS, fn($event) => Str::endsWith($event, 'ed'));
+        $postEvents = array_filter(self::EVENTS, fn ($event) => Str::endsWith($event, 'ed'));
 
         if (in_array($event, $postEvents)) {
             return $attribute


### PR DESCRIPTION
Thanks for this awesome package ❤️ !

The problem is that it is quite opinionated on detecting model changes by using `$model->wasChanged()`. This model function [returns truthly only after the model was changed **and persisted**](https://laravel.com/api/9.x/Illuminate/Database/Eloquent/Concerns/HasAttributes.html#method_wasChanged). Without this fix, any event ending in 'ing' (e.g. `onProgramIdUpdating`) is never executed.

By checking the finish***ed*** events we can still rely on `$model->wasChanged()` but if the model was not yet persisted when the event fired, we need to rely on `$model->isDirty()` instead.

![image](https://user-images.githubusercontent.com/100700999/219675734-7cf43644-0837-4383-a40d-0fc1a18a9499.png)