### PR TITLE
Ensure `created` events are captured properly

### DIFF
--- a/src/LaravelAttributeObserverServiceProvider.php
+++ b/src/LaravelAttributeObserverServiceProvider.php
@@ -76,12 +76,8 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
 
                 foreach ($observedEvents as $observedEvent) {
                     $modelClass::{$observedEvent}(function (Model $model) use ($observedEvent, $observerEventsAttribs, $observerInstance) {
-                        if (! $this->wasChanged($model, $observedEvent)) {
-                            return;
-                        }
-
                         foreach ($observerEventsAttribs[$observedEvent] as $attribute) {
-                            if ($this->modelHasAttribute($model, $attribute) && $this->wasChanged($model, $observedEvent, $attribute)) {
+                            if ($this->modelHasAttribute($model, $attribute)) {
                                 $method = 'on' . Str::studly($attribute) . Str::ucfirst($observedEvent);
                                 $observerInstance->{$method}($model, $model->getAttributeValue($attribute), $model->getOriginal($attribute));
                             }
@@ -143,29 +139,5 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
                 array_key_exists($attribute, $model->getCasts()) ||
                 $model->hasGetMutator($attribute) ||
                 array_key_exists($attribute, $model->getRelations()));
-    }
-
-    /**
-     * Dynamically check if the model was changed or is dirty.
-     *
-     * @param Model $model
-     * @param string $event
-     * @param string|null $attribute
-     * @return bool
-     */
-    private function wasChanged(Model $model, string $event, string $attribute = null): bool
-    {
-        // Pull past-tense/post-mutation events from constants array
-        $postEvents = array_filter(self::EVENTS, fn ($e) => Str::endsWith($e, 'ed'));
-
-        if (in_array($event, $postEvents)) {
-            return $attribute
-                ? $model->wasChanged($attribute)
-                : $model->wasChanged();
-        }
-
-        return $attribute
-            ? $model->isDirty($attribute)
-            : $model->isDirty();
     }
 }

--- a/src/LaravelAttributeObserverServiceProvider.php
+++ b/src/LaravelAttributeObserverServiceProvider.php
@@ -76,8 +76,12 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
 
                 foreach ($observedEvents as $observedEvent) {
                     $modelClass::{$observedEvent}(function (Model $model) use ($observedEvent, $observerEventsAttribs, $observerInstance) {
+                        if (! $this->wasChanged($model, $observedEvent)) {
+                            return;
+                        }
+
                         foreach ($observerEventsAttribs[$observedEvent] as $attribute) {
-                            if ($this->modelHasAttribute($model, $attribute)) {
+                            if ($this->modelHasAttribute($model, $attribute) && $this->wasChanged($model, $observedEvent, $attribute)) {
                                 $method = 'on' . Str::studly($attribute) . Str::ucfirst($observedEvent);
                                 $observerInstance->{$method}($model, $model->getAttributeValue($attribute), $model->getOriginal($attribute));
                             }
@@ -139,5 +143,34 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
                 array_key_exists($attribute, $model->getCasts()) ||
                 $model->hasGetMutator($attribute) ||
                 array_key_exists($attribute, $model->getRelations()));
+    }
+
+    /**
+     * Dynamically check if the model was changed or is dirty.
+     *
+     * @param Model $model
+     * @param string $event
+     * @param string|null $attribute
+     * @return bool
+     */
+    private function wasChanged(Model $model, string $event, string $attribute = null): bool
+    {
+        // Pull past-tense/post-mutation events from constants array
+        $postEvents = array_filter(self::EVENTS, fn ($e) => Str::endsWith($e, 'ed'));
+
+        // If the model was just inserted then all `created` events are valid
+        if ($event === 'created' && $model->wasRecentlyCreated) {
+            return true;
+        }
+
+        if (in_array($event, $postEvents)) {
+            return $attribute
+                ? $model->wasChanged($attribute)
+                : $model->wasChanged();
+        }
+
+        return $attribute
+            ? $model->isDirty($attribute)
+            : $model->isDirty();
     }
 }


### PR DESCRIPTION
Hi Alex,

After some thought (and some unexpected behaviour that we found in our team), it seems that checking if the model attribute has changed seems quite unnecessary and moreover, tricky to accomplish.

The issue that we found was that the created event didn't fire because when you create a new resource, `$model->wasChanged()` and `$model->isDirty()` will both return `false` (so `$this->wasChanged()` will be `false`)

![image](https://user-images.githubusercontent.com/100700999/220615927-e9461571-4b05-484a-a49c-c9fdbf7ce690.png)

The package already relies on Eloquent's own model event firing logic by simply using `$modelClass::{$observedEvent}` so I'd argue that checking if the model was changed at all - is quite opinionated & should be left instead to the developers (users of this package) to handle such logic on their end (in their `App\AttributeObservers\ModelObserver` classes).

This is a breaking change for the current users of the package so, if PR is accepted, I'd suggest a major version change.