### PR TITLE
Make $attribute parameter type explicitly nullable in wasChanged method

### DIFF
--- a/src/LaravelAttributeObserverServiceProvider.php
+++ b/src/LaravelAttributeObserverServiceProvider.php
@@ -161,7 +161,7 @@ class LaravelAttributeObserverServiceProvider extends PackageServiceProvider
      * @param string|null $attribute
      * @return bool
      */
-    private function wasChanged(Model $model, string $event, string $attribute = null): bool
+    private function wasChanged(Model $model, string $event, ?string $attribute = null): bool
     {
         // If the model will be/was deleted then all `delet*` events are valid
         if (Str::startsWith($event, 'delet')) {


### PR DESCRIPTION
Yes, it's a 1-character PR!  This has been driving me nuts for some time.  It just eliminates a flood of these messages in PHP 8.4:
```
PHP Deprecated:  AlexStewartJA\LaravelAttributeObserver\LaravelAttributeObserverServiceProvider::wasChanged(): Implicitly marking parameter $attribute as nullable is deprecated, the explicit nullable type must be used instead in vendor/alexstewartja/laravel-attribute-observer/src/LaravelAttributeObserverServiceProvider.php on line 164
```
